### PR TITLE
Run into can't target terminals inside a tab

### DIFF
--- a/content/modules/ROOT/pages/02-deploy-image.adoc
+++ b/content/modules/ROOT/pages/02-deploy-image.adoc
@@ -28,9 +28,9 @@ runtime of the container image (overlay).
 image::file-system.png[]
 
 Switch to the #*bottom terminal*#. Use this terminal to verify that the
-container is running:
+container is running, by pasting in the following command:
 
-[source,bash,run]
+[source,bash]
 ----
 sudo podman ps -a
 ----

--- a/content/modules/ROOT/pages/02-deploy-image.adoc
+++ b/content/modules/ROOT/pages/02-deploy-image.adoc
@@ -30,7 +30,7 @@ image::file-system.png[]
 Switch to the #*bottom terminal*#. Use this terminal to verify that the
 container is running, by pasting in the following command:
 
-[source,bash]
+[source,sh]
 ----
 sudo podman ps -a
 ----


### PR DESCRIPTION
Can't target bottom terminal, just copy paste via instructions, change the source to `sh` to skip the run button for now.